### PR TITLE
Settings: Expose backgroundTint from Single Button Panel

### DIFF
--- a/res/color/single_button_panel_color.xml
+++ b/res/color/single_button_panel_color.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Copyright (C) 2015 The CyanogenMod Project
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:color="?android:attr/colorAccent" />
+</selector>

--- a/res/layout/single_button_panel.xml
+++ b/res/layout/single_button_panel.xml
@@ -34,7 +34,7 @@
             android:layout_weight="0.4"
             android:layout_height="wrap_content"
             android:layout_gravity="center_vertical"
-            android:backgroundTint="?android:attr/colorAccent"
+            android:backgroundTint="@color/single_button_panel_color"
             android:textColor="@color/text_color_white" />
         <Space
             android:layout_width="0dip"


### PR DESCRIPTION
This exposes the hardcoded backgroundTint call to
?android:attr/colorAccent, and allow the themer to completely
replace the color.

Credits go to @Morningstar for locating the file!

Change-Id: I7d76177fad123173131aecf0d19554825af303a0