### PR TITLE
Dashoard tileview dividers toggle [2/2]

### DIFF
--- a/res/values/du_strings.xml
+++ b/res/values/du_strings.xml
@@ -283,19 +283,18 @@
     <string name="battery_stats_message">Battery history stats are going to be reset</string>
     <string name="ok_string">Ok</string>
 
-    <!-- Dashboard columns -->
+    <!-- Dashboard settings -->
+    <string name="dashboard_category">Dashboard settings</string>
     <string name="dashboard_columns_title">Dashboard Columns</string>
     <string name="dashboard_columns_summary">Change the number of columns displayed in the dashboard</string>
     <string name="dashboard_columns_dialog_title">Select dashboard columns</string>
     <string name="dashboard_columns_one">One</string>
     <string name="dashboard_columns_two">Two</string>
     <string name="dashboard_columns_three">Three</string>
-
-    <!-- Dashboard tileview double lines -->
-    <string name="dashboard_category">Dashboard settings</string>
-    <string name="dashboard_tileview_double_lines_title">Dashboard tile view title</string>
-    <string name="dashboard_tileview_double_lines_summary_on">Show dashboard tile titles in 1 line</string>
-    <string name="dashboard_tileview_double_lines_summary_off">Show dashboard tile titles in 2 lines</string>
+    <string name="dashboard_tileview_double_lines_title">Dashboard title view</string>
+    <string name="dashboard_tileview_double_lines_summary">Show dashboard tile titles in 2 lines</string>
+    <string name="dashboard_tileview_dividers_title">Dashboard dividers</string>
+    <string name="dashboard_tileview_dividers_summary">Hide dashboard tile dividers</string>
 
     <!-- Keyguard notifications options -->
     <string name="app_notification_show_on_keyguard_title">Show on lockscreen</string>

--- a/res/xml/display_settings.xml
+++ b/res/xml/display_settings.xml
@@ -135,8 +135,13 @@
         <com.dirtyunicorns.dutweaks.preference.SystemSettingSwitchPreference
                 android:key="dashboard_tileview_double_lines"
                 android:title="@string/dashboard_tileview_double_lines_title"
-                android:summaryOn="@string/dashboard_tileview_double_lines_summary_on"
-                android:summaryOff="@string/dashboard_tileview_double_lines_summary_off"
+                android:summary="@string/dashboard_tileview_double_lines_summary"
+                android:defaultValue="false" />
+
+        <com.dirtyunicorns.dutweaks.preference.SystemSettingSwitchPreference
+                android:key="dashboard_tileview_dividers"
+                android:title="@string/dashboard_tileview_dividers_title"
+                android:summary="@string/dashboard_tileview_dividers_summary"
                 android:defaultValue="false" />
 
         </PreferenceCategory>

--- a/src/com/android/settings/dashboard/DashboardTileView.java
+++ b/src/com/android/settings/dashboard/DashboardTileView.java
@@ -63,7 +63,14 @@ public class DashboardTileView extends FrameLayout implements View.OnClickListen
         }
 
         mStatusTextView = (TextView) view.findViewById(R.id.status);
+
         mDivider = view.findViewById(R.id.tile_divider);
+        if (Settings.System.getInt(mContext.getContentResolver(),
+                Settings.System.DASHBOARD_TILEVIEW_DIVIDERS, 0) == 1) {
+        mDivider.setVisibility(View.GONE);
+        } else {
+        mDivider.setVisibility(View.VISIBLE);
+        }
 
         setOnClickListener(this);
         setBackgroundResource(R.drawable.dashboard_tile_background);


### PR DESCRIPTION
Inspired once again by @xWASABI in a commit where he allowed for themers to hide
the dividers via styles, I figure we could make this configurable without installing
a theme :-)

https://github.com/TeamTwisted/packages_apps_Settings/commit/d72a5999b4e441784fea53bd89f487bbd0d0424c

- Cleaned up some of the strings for previous dashboard-like commits

See images :
http://i.imgur.com/unf5BCy.png
http://i.imgur.com/kPQA766.png
http://i.imgur.com/At7b6FQ.png
http://i.imgur.com/ZEvxHOT.png

Change-Id: Ie47ddf09f577831dcc1bb2affb12b30f425849c8